### PR TITLE
Package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ function with a token provided to set up the API client.
 ```go
 package main
 
-import "github.com/liveoaklabs/readme-api-go-client/readme"
+import "github.com/lobliveoaklabs/readme-api-go-client/readme"
 
 const readmeAPIKey string = "rdme_xxxxxxxx..."
 
@@ -60,5 +60,5 @@ This project uses a few [tools](readme/tools.go) for validating code quality and
 
 ## References
 
-* [Terraform provider for ReadMe](https://github.com/liveoaklabs/terraform-provider-readme):
+* [Terraform provider for ReadMe](https://github.com/lobliveoaklabs/terraform-provider-readme):
   Related project using this client library.

--- a/README.md
+++ b/README.md
@@ -38,15 +38,9 @@ if specs == nil {
 }
 ```
 
-## Reference
-
-Refer to [`docs/README.md`](docs/README.md) for the Go package documentation.
-
 ## Development
 
 * Merge requests should merge into the `main` branch.
-* Use the GitLab labels _Patch_, _Minor_, and _Major_ as appropriate on a merge
-  request to tag the release according to [semantic versioning](https://semver.org/).
 * Refer to the [`Makefile`](Makefile) for helpful development tasks.
 
 This project uses a few [tools](readme/tools.go) for validating code quality and functionality:

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/liveoaklabs/readme-api-go-client
+module github.com/lobliveoaklabs/readme-api-go-client
 
 go 1.19
 
@@ -7,7 +7,7 @@ require (
 	github.com/golangci/golangci-lint v1.51.2
 	github.com/princjef/gomarkdoc v0.4.1
 	github.com/stretchr/testify v1.8.1
-	golang.org/x/vuln v0.0.0-20230217204342-b91abcc5ae3c
+	golang.org/x/vuln v0.0.0-20230221181318-b1b4de0d2042
 	mvdan.cc/gofumpt v0.4.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -115,6 +115,7 @@ github.com/charithe/durationcheck v0.0.9 h1:mPP4ucLrf/rKZiIG/a9IPXHGlh8p4CzgpyTy
 github.com/charithe/durationcheck v0.0.9/go.mod h1:SSbRIBVfMjCi/kEB6K65XEA83D6prSM8ap1UCpNKtgg=
 github.com/chavacava/garif v0.0.0-20221024190013-b3ef35877348 h1:cy5GCEZLUCshCGCRRUjxHrDUqkB4l5cuUt3ShEckQEo=
 github.com/chavacava/garif v0.0.0-20221024190013-b3ef35877348/go.mod h1:f/miWtG3SSuTxKsNK3o58H1xl+XV6ZIfbC6p7lPPB8U=
+github.com/cheggaaa/pb v2.0.7+incompatible h1:gLKifR1UkZ/kLkda5gC0K6c8g+jU2sINPtBeOiNlMhU=
 github.com/cheggaaa/pb v2.0.7+incompatible/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
 github.com/cheggaaa/pb/v3 v3.0.4/go.mod h1:7rgWxLrAUcFMkvJuv09+DYi7mMUYi8nO9iOWcvGJPfw=
 github.com/cheggaaa/pb/v3 v3.1.0 h1:3uouEsl32RL7gTiQsuaXD4Bzbfl5tGztXGUvXbs4O04=
@@ -471,6 +472,7 @@ github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJ
 github.com/otiai10/curr v1.0.0/go.mod h1:LskTG5wDwr8Rs+nNQ+1LlxRjAtTZZjtJW4rMXl6j4vs=
 github.com/otiai10/mint v1.3.0/go.mod h1:F5AjcsTsWUqX+Na9fpHb52P8pcRX2CI6A3ctIT91xUo=
 github.com/otiai10/mint v1.3.1/go.mod h1:/yxELlJQ0ufhjUwhshSj+wFjZ78CnZ48/1wtmBH1OTc=
+github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
 github.com/pelletier/go-toml/v2 v2.0.6 h1:nrzqCb7j9cDFj2coyLNLaZuJTLjWjlaz6nvTvIwycIU=
 github.com/pelletier/go-toml/v2 v2.0.6/go.mod h1:eumQOmlWiOPt5WriQQqoM5y18pDHwha2N+QD+EUNTek=
 github.com/pjbgf/sha1cd v0.2.3 h1:uKQP/7QOzNtKYH7UTohZLcjF5/55EnTw0jO/Ru4jZwI=
@@ -955,6 +957,8 @@ golang.org/x/tools v0.6.1-0.20230217175706-3102dad5faf9 h1:IuFp2CklNBim6OdHXn/1P
 golang.org/x/tools v0.6.1-0.20230217175706-3102dad5faf9/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=
 golang.org/x/vuln v0.0.0-20230217204342-b91abcc5ae3c h1:7/jJkMpaKZMxdyOQ7IP7aPbJQaDk4cOUxtXtWHQ1cSk=
 golang.org/x/vuln v0.0.0-20230217204342-b91abcc5ae3c/go.mod h1:LTLnfk/dpXDNKsX6aCg/cI4LyCVnTyrQhgV/yLJuly0=
+golang.org/x/vuln v0.0.0-20230221181318-b1b4de0d2042 h1:kyqkq4gCHoUi902lKOS1/IIEWCT0pJvgh1vMgQmex8c=
+golang.org/x/vuln v0.0.0-20230221181318-b1b4de0d2042/go.mod h1:LTLnfk/dpXDNKsX6aCg/cI4LyCVnTyrQhgV/yLJuly0=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/liveoaklabs/readme-api-go-client/readme"
+	"github.com/lobliveoaklabs/readme-api-go-client/readme"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/readme/api_registry_test.go
+++ b/readme/api_registry_test.go
@@ -3,8 +3,8 @@ package readme_test
 import (
 	"testing"
 
-	"github.com/liveoaklabs/readme-api-go-client/internal/testutil"
-	"github.com/liveoaklabs/readme-api-go-client/readme"
+	"github.com/lobliveoaklabs/readme-api-go-client/internal/testutil"
+	"github.com/lobliveoaklabs/readme-api-go-client/readme"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/readme/api_specification_test.go
+++ b/readme/api_specification_test.go
@@ -4,8 +4,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/liveoaklabs/readme-api-go-client/internal/testutil"
-	"github.com/liveoaklabs/readme-api-go-client/readme"
+	"github.com/lobliveoaklabs/readme-api-go-client/internal/testutil"
+	"github.com/lobliveoaklabs/readme-api-go-client/readme"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/readme/apply_test.go
+++ b/readme/apply_test.go
@@ -3,8 +3,8 @@ package readme_test
 import (
 	"testing"
 
-	"github.com/liveoaklabs/readme-api-go-client/internal/testutil"
-	"github.com/liveoaklabs/readme-api-go-client/readme"
+	"github.com/lobliveoaklabs/readme-api-go-client/internal/testutil"
+	"github.com/lobliveoaklabs/readme-api-go-client/readme"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/readme/category_test.go
+++ b/readme/category_test.go
@@ -5,8 +5,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/liveoaklabs/readme-api-go-client/internal/testutil"
-	"github.com/liveoaklabs/readme-api-go-client/readme"
+	"github.com/lobliveoaklabs/readme-api-go-client/internal/testutil"
+	"github.com/lobliveoaklabs/readme-api-go-client/readme"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/readme/changelog_test.go
+++ b/readme/changelog_test.go
@@ -3,8 +3,8 @@ package readme_test
 import (
 	"testing"
 
-	"github.com/liveoaklabs/readme-api-go-client/internal/testutil"
-	"github.com/liveoaklabs/readme-api-go-client/readme"
+	"github.com/lobliveoaklabs/readme-api-go-client/internal/testutil"
+	"github.com/lobliveoaklabs/readme-api-go-client/readme"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/readme/custom_page_test.go
+++ b/readme/custom_page_test.go
@@ -4,8 +4,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/liveoaklabs/readme-api-go-client/internal/testutil"
-	"github.com/liveoaklabs/readme-api-go-client/readme"
+	"github.com/lobliveoaklabs/readme-api-go-client/internal/testutil"
+	"github.com/lobliveoaklabs/readme-api-go-client/readme"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/readme/doc_test.go
+++ b/readme/doc_test.go
@@ -3,8 +3,8 @@ package readme_test
 import (
 	"testing"
 
-	"github.com/liveoaklabs/readme-api-go-client/internal/testutil"
-	"github.com/liveoaklabs/readme-api-go-client/readme"
+	"github.com/lobliveoaklabs/readme-api-go-client/internal/testutil"
+	"github.com/lobliveoaklabs/readme-api-go-client/readme"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/readme/project_test.go
+++ b/readme/project_test.go
@@ -3,8 +3,8 @@ package readme_test
 import (
 	"testing"
 
-	"github.com/liveoaklabs/readme-api-go-client/internal/testutil"
-	"github.com/liveoaklabs/readme-api-go-client/readme"
+	"github.com/lobliveoaklabs/readme-api-go-client/internal/testutil"
+	"github.com/lobliveoaklabs/readme-api-go-client/readme"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/readme/readme_test.go
+++ b/readme/readme_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/liveoaklabs/readme-api-go-client/readme"
+	"github.com/lobliveoaklabs/readme-api-go-client/readme"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/readme/version_test.go
+++ b/readme/version_test.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/liveoaklabs/readme-api-go-client/internal/testutil"
-	"github.com/liveoaklabs/readme-api-go-client/readme"
+	"github.com/lobliveoaklabs/readme-api-go-client/internal/testutil"
+	"github.com/lobliveoaklabs/readme-api-go-client/readme"
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
* Update the package name to match the GitHub organization.
* Remove the reference to the 'docs' within this repo. Now that the project's published, we'll handle docs differently.
* Remove reference to GitLab labels for versioning.