### PR TITLE
ci: release, tags, and changelog

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,34 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+  - title: '🧰 Maintenance'
+    labels:
+      - 'chore'
+      - 'ci'
+      - 'docs'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'patch'
+  default: patch
+template: |
+  ## Changes
+
+  $CHANGES

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,35 @@
+# Updates the CHANGELOG.md file when new releases are created.
+# See https://github.com/marketplace/actions/changelog-updater for more information.
+name: "Update Changelog"
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+
+    permissions:
+      # Give the default GITHUB_TOKEN write permission to commit and push the updated CHANGELOG back to the repository.
+      # https://github.blog/changelog/2023-02-02-github-actions-updating-the-default-github_token-permissions-to-read-only/
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.release.target_commitish }}
+
+      - name: Update Changelog
+        uses: stefanzweifel/changelog-updater-action@v1
+        with:
+          latest-version: ${{ github.event.release.tag_name }}
+          release-notes: ${{ github.event.release.body }}
+
+      - name: Commit updated CHANGELOG
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          branch: ${{ github.event.release.target_commitish }}
+          commit_message: Update CHANGELOG
+          file_pattern: CHANGELOG.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+# Maintains a release draft for all PRs into "main".
+# See https://github.com/marketplace/actions/release-drafter for more information.
+name: Release Drafter
+
+on:
+  push:
+    # branches to consider in the event; optional, defaults to all
+    branches:
+      - main
+  # pull_request event is required only for autolabeler
+  pull_request:
+    # Only following types are handled by the action, but one can default to all as well
+    types: [opened, reopened, synchronize]
+  # pull_request_target event is required for autolabeler to support PRs from forks
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Changelog

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,32 @@
+# Contributing
+
+Merge requests should be opened to merge into the `main` branch.
+
+## GitHub Labels
+
+* Use `patch`, `minor`, or `major` to indicate the [semantic version](https://semver.org/) for a
+  change. If unsure, a project maintainer will set it.
+* Use `feature` or `enhancement` for added features.
+* Use `fix`, `bugfix` or `bug` for fixed bugs.
+* Use `chore`, `ci`, and `docs` for maintenance tasks.
+
+## Releases
+
+This project uses the [Release Drafter](https://github.com/marketplace/actions/release-drafter)
+action for managing releases and tags.
+
+The [Changelog Updater](https://github.com/marketplace/actions/changelog-updater) action updates the
+[`CHANGELOG.md`](https://github.com/marketplace/actions/changelog-updater) file when releases are
+published.
+
+## Tools and Tests
+
+This project uses a few [tools](readme/tools.go) for validating code quality and functionality:
+
+* [pre-commit](https://pre-commit.com/) for ensuring consistency and code quality before committing (external dependency).
+* [golangci-lint](https://golangci-lint.run/) for linting and formatting.
+* [gofumpt](https://github.com/mvdan/gofumpt) (is included with golangci-lint).
+* [gocover-cobertura](https://github.com/boumenot/gocover-cobertura) for code test coverage reporting.
+* [govulncheck](https://github.com/golang/vuln) for detecting vulnerabilities in Go packages.
+
+Refer to the [`Makefile`](Makefile) for helpful development tasks.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Go Client for the ReadMe.com API
 
+[![Version](https://img.shields.io/github/v/release/lobliveoaklabs/readme-api-go-client)](https://github.com/lobliveoaklabs/readme-api-go-client/releases)
+[![CodeQL](https://github.com/lobliveoaklabs/readme-api-go-client/workflows/CodeQL/badge.svg)](https://github.com/lobliveoaklabs/readme-api-go-client/actions?query=workflow%3ACodeQL)
+[![Tests](https://github.com/lobliveoaklabs/readme-api-go-client/actions/workflows/tests.yml/badge.svg)](https://github.com/lobliveoaklabs/readme-api-go-client/actions/workflows/tests.yml)
+[![GoDoc](https://godoc.org/github.com/golang/gddo?status.svg)](https://pkg.go.dev/github.com/lobliveoaklabs/readme-api-go-client?tab=doc)
+
 This is a Go client library for the [ReadMe.com](https://readme.com) API.
 
 ## Getting Started
@@ -42,21 +47,14 @@ if specs == nil {
 
 Refer to <https://pkg.go.dev/github.com/lobliveoaklabs/readme-api-go-client> for the Go package documentation.
 
-## Development
+## Contributing
 
-* Merge requests should merge into the `main` branch.
-* Refer to the [`Makefile`](Makefile) for helpful development tasks.
+Refer to [`CONTRIBUTING.md`](CONTRIBUTING.md) for information on contributing to this project.
 
-This project uses a few [tools](readme/tools.go) for validating code quality and functionality:
+## Related
 
-* [pre-commit](https://pre-commit.com/) for ensuring consistency and code quality before committing (external dependency).
-* [golangci-lint](https://golangci-lint.run/) for linting and formatting.
-* [gofumpt](https://github.com/mvdan/gofumpt) (is included with golangci-lint).
-* [gocover-cobertura](https://github.com/boumenot/gocover-cobertura) for code test coverage reporting.
-* [govulncheck](https://github.com/golang/vuln) for detecting vulnerabilities in Go packages.
-* [gomarkdoc](https://github.com/princjef/gomarkdoc) for generating the [Markdown docs](docs/README.md).
+[Terraform provider for ReadMe](https://github.com/lobliveoaklabs/terraform-provider-readme) uses this client library.
 
-## References
+## License
 
-* [Terraform provider for ReadMe](https://github.com/lobliveoaklabs/terraform-provider-readme):
-  Related project using this client library.
+This project is licensed under the MIT License - see the [`LICENSE`](LICENSE) file for details.


### PR DESCRIPTION
Add a GitHub action workflow for creating releases from pull requests and updating the changelog file when new releases are created.

Add a related `CONTRIBUTING` doc.

This uses the "Release Drafter" and "Changelog Updater" GitHub actions:

* https://github.com/marketplace/actions/release-drafter
* https://github.com/marketplace/actions/changelog-updater